### PR TITLE
Removed empty line

### DIFF
--- a/PRODUCTS/legislativas_2022_CNE_all_13JAN2022.csv
+++ b/PRODUCTS/legislativas_2022_CNE_all_13JAN2022.csv
@@ -2087,7 +2087,6 @@ Leiria,R.I.R.,Vítor Manuel Inglês Marques Santos,efetivo
 Leiria,R.I.R.,Carina Isabel Oliveira Martinho,suplente
 Leiria,R.I.R.,Rui Gonçalo Timóteo Baptista,suplente
 Leiria,R.I.R.,Eugénia Maria Firmino Silva Falacho,suplente
-Lisboa,LIVRE,,efetivo
 Lisboa,LIVRE,Rui Miguel Marcelino Tavares Pereira,efetivo
 Lisboa,LIVRE,Isabel Rendeiro Marques Mendes Lopes,efetivo
 Lisboa,LIVRE,Carlos Manuel Guilherme Lage Teixeira,efetivo


### PR DESCRIPTION
Removed an empty line. The list of candidates from LIVRE to Lisbon is correct.